### PR TITLE
update

### DIFF
--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1919,14 +1919,12 @@ bool PremiumItemOk(const Player &player, const ItemData &item)
 	if (!gbIsHellfire && item.itype == ItemType::Staff)
 		return false;
 
-	if (gbIsMultiplayer) {
-		if (item.iMiscId == IMISC_OILOF)
-			return false;
-		if (item.itype == ItemType::Ring)
-			return false;
-		if (item.itype == ItemType::Amulet)
-			return false;
-	}
+	if (item.iMiscId == IMISC_OILOF)
+		return false;
+	if (item.itype == ItemType::Ring)
+		return false;
+	if (item.itype == ItemType::Amulet)
+		return false;
 
 	return true;
 }
@@ -2112,7 +2110,7 @@ void RecreateBoyItem(const Player &player, Item &item, int lvl, int iseed)
 	SetRndSeed(iseed);
 	_item_indexes itype = RndBoyItem(player, lvl);
 	GetItemAttrs(item, itype, lvl);
-	GetItemBonus(player, item, lvl, 2 * lvl, true, true);
+	GetItemBonus(player, item, lvl, 2 * lvl + 1, true, true);
 
 	item._iSeed = iseed;
 	item._iCreateInfo = lvl | CF_BOY;
@@ -2133,9 +2131,9 @@ void RecreateWitchItem(const Player &player, Item &item, _item_indexes idx, int 
 		GetItemAttrs(item, itype, lvl);
 		int iblvl = -1;
 		if (GenerateRnd(100) <= 5)
-			iblvl = 2 * lvl;
+			iblvl = 2 * lvl + 1;
 		if (iblvl == -1 && item._iMiscId == IMISC_STAFF)
-			iblvl = 2 * lvl;
+			iblvl = 2 * lvl + 1;
 		if (iblvl != -1)
 			GetItemBonus(player, item, iblvl / 2, iblvl, true, true);
 	}
@@ -4152,9 +4150,9 @@ void SpawnWitch(int lvl)
 			GetItemAttrs(item, itemData, lvl);
 			int maxlvl = -1;
 			if (GenerateRnd(100) <= 5)
-				maxlvl = 2 * lvl;
+				maxlvl = 2 * lvl + 1;
 			if (maxlvl == -1 && item._iMiscId == IMISC_STAFF)
-				maxlvl = 2 * lvl;
+				maxlvl = 2 * lvl + 1;
 			if (maxlvl != -1)
 				GetItemBonus(*MyPlayer, item, maxlvl / 2, maxlvl, true, true);
 		} while (item._iIvalue > maxValue);
@@ -4191,7 +4189,7 @@ void SpawnBoy(int lvl)
 		SetRndSeed(boyitem._iSeed);
 		_item_indexes itype = RndBoyItem(*MyPlayer, lvl);
 		GetItemAttrs(boyitem, itype, lvl);
-		GetItemBonus(*MyPlayer, boyitem, lvl, 2 * lvl, true, true);
+		GetItemBonus(*MyPlayer, boyitem, lvl, 2 * lvl + 1, true, true);
 
 		if (!gbIsHellfire) {
 			if (boyitem._iIvalue > 144000) {

--- a/Source/levels/trigs.cpp
+++ b/Source/levels/trigs.cpp
@@ -77,11 +77,20 @@ bool IsWarpOpen(dungeon_type type)
 
 	Player &myPlayer = *MyPlayer;
 
-	if (type == DTYPE_CATACOMBS && (myPlayer.pTownWarps & 1) != 0)
+	if ((type == DTYPE_CATACOMBS && (myPlayer.pTownWarps & 1) != 0)
+	    || (sgGameInitInfo.nDifficulty == DIFF_NORMAL && myPlayer.pDiabloKillLevel >= 1)
+		|| (sgGameInitInfo.nDifficulty == DIFF_NIGHTMARE && myPlayer.pDiabloKillLevel >= 2)
+	    || (sgGameInitInfo.nDifficulty == DIFF_HELL && myPlayer.pDiabloKillLevel == 3))
 		return true;
-	if (type == DTYPE_CAVES && (myPlayer.pTownWarps & 2) != 0)
+	if ((type == DTYPE_CAVES && (myPlayer.pTownWarps & 2) != 0)
+	    || (sgGameInitInfo.nDifficulty == DIFF_NORMAL && myPlayer.pDiabloKillLevel >= 1)
+	    || (sgGameInitInfo.nDifficulty == DIFF_NIGHTMARE && myPlayer.pDiabloKillLevel >= 2)
+	    || (sgGameInitInfo.nDifficulty == DIFF_HELL && myPlayer.pDiabloKillLevel == 3))
 		return true;
-	if (type == DTYPE_HELL && (myPlayer.pTownWarps & 4) != 0)
+	if ((type == DTYPE_HELL && (myPlayer.pTownWarps & 4) != 0)
+	    || (sgGameInitInfo.nDifficulty == DIFF_NORMAL && myPlayer.pDiabloKillLevel >= 1)
+	    || (sgGameInitInfo.nDifficulty == DIFF_NIGHTMARE && myPlayer.pDiabloKillLevel >= 2)
+	    || (sgGameInitInfo.nDifficulty == DIFF_HELL && myPlayer.pDiabloKillLevel == 3))
 		return true;
 
 	if (gbIsHellfire) {

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -2486,13 +2486,11 @@ void AddPlrExperience(Player &player, int lvl, int exp)
 	uint32_t clampedExp = std::max(static_cast<int>(exp * (1 + (lvl - player._pLevel) / 10.0)), 0);
 
 	// Prevent power leveling
-	if (gbIsMultiplayer) {
-		const uint32_t clampedPlayerLevel = clamp(static_cast<int>(player._pLevel), 1, MaxCharacterLevel);
+	const uint32_t clampedPlayerLevel = clamp(static_cast<int>(player._pLevel), 1, MaxCharacterLevel);
 
-		// for low level characters experience gain is capped to 1/20 of current levels xp
-		// for high level characters experience gain is capped to 200 * current level - this is a smaller value than 1/20 of the exp needed for the next level after level 5.
-		clampedExp = std::min({ clampedExp, /* level 0-5: */ ExpLvlsTbl[clampedPlayerLevel] / 20U, /* level 6-50: */ 200U * clampedPlayerLevel });
-	}
+	// for low level characters experience gain is capped to 1/20 of current levels xp
+	// for high level characters experience gain is capped to 200 * current level - this is a smaller value than 1/20 of the exp needed for the next level after level 5.
+	clampedExp = std::min({ clampedExp, /* level 0-5: */ ExpLvlsTbl[clampedPlayerLevel] / 20U, /* level 6-50: */ 200U * clampedPlayerLevel });
 
 	constexpr uint32_t MaxExperience = 2000000000U;
 

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -2236,15 +2236,7 @@ void SetupTownStores()
 	Player &myPlayer = *MyPlayer;
 
 	int l = myPlayer._pLevel / 2;
-	if (!gbIsMultiplayer) {
-		l = 0;
-		for (int i = 0; i < NUMLEVELS; i++) {
-			if (myPlayer._pLvlVisited[i])
-				l = i;
-		}
-	} else {
-		SetRndSeed(glSeedTbl[currlevel] * SDL_GetTicks());
-	}
+	SetRndSeed(glSeedTbl[currlevel] * SDL_GetTicks());
 
 	l = clamp(l + 2, 6, 16);
 	SpawnSmith(l);


### PR DESCRIPTION
- single player experience cap same as multiplayer
- no jewelry sold by Wirt and Griswold in single player
- stores base items are calculated from character level rather than dungeon level visited in single player
- Adria and Wirt maximum affix qlvl: 2*clvl+1
- dungeon entrances in single player games can be accessed depending on Diablo kills